### PR TITLE
Add support for running CrustalRuby without Crystal in dry mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Added support for running `crustalruby` without the `crystal` binary in dry mode. [#15]
+
 ## [0.1.4] - 2024-04-10
 
 - Fix bug in type checking on deserialization of union types

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    crystalruby (0.2.1)
+    crystalruby (0.2.3)
       digest
       ffi
       fileutils

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ $ gem install crystalruby
 You can run `crystalruby init` to generate a configuration file with sane defaults.
 
 ```bash
-crystalruby init
+$ crystalruby init
 ```
 
 ```yaml
@@ -610,6 +610,7 @@ Alternatively, these can be set programmatically, e.g:
 CrystalRuby.configure do |config|
   config.crystal_src_dir = "./crystalruby"
   config.crystal_codegen_dir = "generated"
+  config.crystal_missing_ignore = false
   config.debug = true
   config.verbose = false
   config.colorize_log_output = false

--- a/exe/crystalruby
+++ b/exe/crystalruby
@@ -10,6 +10,7 @@ def init
     # crystalruby configuration file
     crystal_src_dir: "./crystalruby"
     crystal_codegen_dir: "generated"
+    crystal_missing_ignore: false
     log_level: "info"
     single_thread_mode: false
     debug: true

--- a/lib/crystalruby.rb
+++ b/lib/crystalruby.rb
@@ -37,19 +37,25 @@ module CrystalRuby
   def check_crystal_ruby!
     return if system("which crystal > /dev/null 2>&1")
 
-    raise "Crystal executable not found. Please ensure Crystal is installed and in your PATH." \
-      "See https://crystal-lang.org/install/"
+    msg = "Crystal executable not found. Please ensure Crystal is installed and in your PATH. " \
+      "See https://crystal-lang.org/install/."
+
+    if config.crystal_missing_ignore
+      config.logger.error msg
+    else
+      raise msg
+    end
   end
 
   def check_config!
     return if config.crystal_src_dir
 
-    raise "Missing config option `crystal_src_dir`. \nProvide this inside crystalruby.yaml "\
+    raise "Missing config option `crystal_src_dir`. \nProvide this inside crystalruby.yaml " \
       "(run `bundle exec crystalruby init` to generate this file with detaults)"
   end
 
   %w[debug info warn error].each do |level|
-    define_method("log_#{level}") do |*msg|
+    define_method(:"log_#{level}") do |*msg|
       prefix = config.colorize_log_output ? "\e[33mcrystalruby\e[0m\e[90m [#{Thread.current.object_id}]\e[0m" : "[crystalruby] #{Thread.current.object_id}"
 
       config.logger.send(level, "#{prefix} #{msg.join(", ")}")

--- a/lib/crystalruby/config.rb
+++ b/lib/crystalruby/config.rb
@@ -17,26 +17,26 @@ module CrystalRuby
   # - CrystalRuby.configure block
   class Configuration
     include Singleton
-    attr_accessor :debug, :verbose, :logger, :colorize_log_output, :single_thread_mode
+    attr_accessor :debug, :verbose, :logger, :colorize_log_output,
+      :single_thread_mode, :crystal_missing_ignore
 
     def initialize
       @debug = true
       @paths_cache = {}
-      config = File.exist?("crystalruby.yaml") && begin
-        YAML.safe_load(IO.read("crystalruby.yaml"))
-      rescue StandardError
-        nil
-      end || {}
-      @crystal_src_dir      = config.fetch("crystal_src_dir", "./crystalruby")
-      @crystal_codegen_dir  = config.fetch("crystal_codegen_dir", "generated")
-      @crystal_project_root = config.fetch("crystal_project_root", Pathname.pwd)
-      @debug                = config.fetch("debug", true)
-      @verbose              = config.fetch("verbose", false)
-      @single_thread_mode   = config.fetch("single_thread_mode", false)
-      @colorize_log_output  = config.fetch("colorize_log_output", false)
-      @log_level            = config.fetch("log_level", ENV.fetch("CRYSTALRUBY_LOG_LEVEL", "info"))
-      @logger               = Logger.new(STDOUT)
-      @logger.level         = Logger.const_get(@log_level.to_s.upcase)
+      config = read_config || {}
+      @crystal_src_dir        = config.fetch("crystal_src_dir", "./crystalruby")
+      @crystal_codegen_dir    = config.fetch("crystal_codegen_dir", "generated")
+      @crystal_project_root   = config.fetch("crystal_project_root", Pathname.pwd)
+      @crystal_missing_ignore = config.fetch("crystal_missing_ignore", false)
+      @debug                  = config.fetch("debug", true)
+      @verbose                = config.fetch("verbose", false)
+      @single_thread_mode     = config.fetch("single_thread_mode", false)
+      @colorize_log_output    = config.fetch("colorize_log_output", false)
+      @log_level              = config.fetch("log_level", ENV.fetch("CRYSTALRUBY_LOG_LEVEL", "info"))
+      @logger                 = Logger.new($stdout)
+      @logger.level           = Logger.const_get(@log_level.to_s.upcase)
+
+
     end
 
     %w[crystal_project_root].each do |method_name|
@@ -70,6 +70,14 @@ module CrystalRuby
     def log_level=(level)
       @log_level = level
       @logger.level = Logger.const_get(level.to_s.upcase)
+    end
+
+    private
+
+    def read_config
+      YAML.safe_load(IO.read("crystalruby.yaml"))
+    rescue
+      {}
     end
   end
 

--- a/lib/crystalruby/library.rb
+++ b/lib/crystalruby/library.rb
@@ -44,7 +44,7 @@ module CrystalRuby
       ].each do |dir|
         FileUtils.mkdir_p(dir)
       end
-      IO.write  main_file, "require \"./#{config.crystal_codegen_dir}/index\"\n" unless File.exist?(main_file)
+      IO.write main_file, "require \"./#{config.crystal_codegen_dir}/index\"\n" unless File.exist?(main_file)
 
       return if File.exist?(shard_file)
 


### PR DESCRIPTION
Introduce a new config option `crystal_missing_ignore`, which defaults to `false`. When enabled, the application can run without the `crystal` binary. If `crystal` is missing, the library will not be compiled, but the Ruby application will still run as-is.

This change simplifies onboarding by removing the requirement for all developers to install `crystal`.