### PR TITLE
Update example to support 0.3 version

### DIFF
--- a/examples/adder/adder.rb
+++ b/examples/adder/adder.rb
@@ -1,8 +1,8 @@
 require "crystalruby"
 
 module Adder
-  crystalize [a: :int, b: :int] => :int
-  def add(a, b)
+  crystalize :int
+  def add(a: :int, b: :int)
     a + b
   end
 end


### PR DESCRIPTION
Currently the example provides error:

```
$ bundle exec ruby examples/adder/adder.rb 
/Users/miry/src/wouterken/crystalruby/lib/crystalruby/adapter.rb:39:in `crystalize': unknown keyword: [{:a=>:int, :b=>:int}] (ArgumentError)
	from examples/adder/adder.rb:4:in `<module:Adder>'
	from examples/adder/adder.rb:3:in `<main>'
```
