### PR TITLE
Update example to support 0.3.1 version

### DIFF
--- a/examples/adder/adder.rb
+++ b/examples/adder/adder.rb
@@ -1,8 +1,8 @@
 require "crystalruby"
 
 module Adder
-  crystallize [a: :int, b: :int] => :int
-  def add(a, b)
+  crystallize :int
+  def add(a: :int, b: :int)
     a + b
   end
 end


### PR DESCRIPTION
It appears that the changes from https://github.com/wouterken/crystalruby/pull/18 were reverted by [this commit](https://github.com/wouterken/crystalruby/commit/10a593a0605b01267e486237aa3b47770b088fe9). Likely due to the significant changes, these updates may have been unintentionally missed while resolving conflicts.

I'm resending the changes for review.

## Tohat

### Local

```shell
$ bundle exec ruby examples/adder/adder.rb
3
```