### PR TITLE
Bump prism to 1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       digest
       ffi
       fileutils (~> 1.7)
-      prism (~> 1.3.0)
+      prism (>= 1.3.0, < 1.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +36,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    prism (1.3.0)
+    prism (1.4.0)
     psych (5.1.2)
       stringio
     racc (1.7.3)
@@ -79,4 +79,4 @@ DEPENDENCIES
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.5.3
+   2.6.8

--- a/crystalruby.gemspec
+++ b/crystalruby.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "digest"
   spec.add_dependency "ffi"
   spec.add_dependency "fileutils", "~> 1.7"
-  spec.add_dependency "prism", "~> 1.3.0"
+  spec.add_dependency "prism", ">= 1.3.0", "< 1.5.0"
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 end


### PR DESCRIPTION
Solve the dependencies lock:

```
Because every version of crystalruby depends on prism ~> 1.3.0
  and rubocop-ast >= 1.43.0 depends on prism ~> 1.4,
  every version of crystalruby is incompatible with rubocop-ast >= 1.43.0.
And because rubocop >= 1.75.2 depends on rubocop-ast >= 1.44.0, < 2.0
  and standard >= 1.48.0 depends on rubocop ~> 1.75.2,
  every version of crystalruby is incompatible with standard >= 1.48.0.
```